### PR TITLE
Adding bp.middlewares.load() on step 11 of tutorial

### DIFF
--- a/motivation-bot/README.md
+++ b/motivation-bot/README.md
@@ -162,6 +162,8 @@ const pickCategory = {
 
 module.exports = function(bp) {
 
+  bp.middlewares.load()
+
   bp.hear({
     type: 'postback',
     text: 'GET_STARTED'


### PR DESCRIPTION
On step 11 of the tutorial is missing the instruction `bp.middlewares.load()`, what already caused confusion on the community.